### PR TITLE
[dependencies] Improve dependency declaration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,31 @@
 language: php
 
-php:
-  - 7.0
-  - 7.1
-  - hhvm
-
 sudo: false
 
-install: travis_retry composer install --no-interaction --prefer-dist
-
-script: phpunit --coverage-text
-
 matrix:
+  include:
+    - php: 7.0
+    - php: 7.0
+      env: dependencies=lowest
+    - php: 7.1
+    - php: 7.1
+      env: dependencies=lowest
+    - php: 7.2
+    - php: 7.2
+      env: dependencies=lowest
+    - php: nighly
+    - php: nighly
+      env: dependencies=lowest
   allow_failures:
-    - php: hhvm
+    - php: nighly
   fast_finish: true
+
+install:
+    - |
+        if [[ "$dependencies" = "lowest" ]]; then
+          travis_retry composer update --no-interaction --prefer-lowest --prefer-stable -n
+        else
+          travis_retry composer install --no-interaction --prefer-dist
+        fi
+
+script: vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.4"
+        "phpunit/phpunit": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,6 +30,11 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/Cron/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.3-dev"
         }
     }
 }


### PR DESCRIPTION
* Use SemVer to only allow releases from PHP 7.x branches;
* Add support for `phpunit/phpunit: ^7.0`;
* Add CI support to execute tests with PHP `7.2` and PHP `nightly`, removing `hhvm`;
* Add tests for all supported PHP versions with lowest dependencies;
* Use own `phpunit/phpunit` dev dependency instead of relying on the Travis built in version;
* Add "extra.branch-alias" at `composer.json` in order to allow installs for dev versions while respecting SemVer.