### PR TITLE
Fixed infinite loop when resolving last weekday of the month from literals

### DIFF
--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -49,7 +49,9 @@ class DayOfWeekField extends AbstractField
 
         // Find out if this is the last specific weekday of the month
         if (strpos($value, 'L')) {
-            $weekday = str_replace('7', '0', substr($value, 0, strpos($value, 'L')));
+            $weekday = $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
+            $weekday = str_replace('7', '0', $weekday);
+
             $tdate = clone $date;
             $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
             while ($tdate->format('w') != $weekday) {

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -104,6 +104,18 @@ class DayOfWeekFieldTest extends TestCase
     }
 
     /**
+     * @covers \Cron\DayOfWeekField::isSatisfiedBy
+     */
+    public function testHandlesLastWeekdayOfTheMonth()
+    {
+        $f = new DayOfWeekField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), 'FRIL'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), '5L'));
+        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), 'FRIL'));
+        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), '5L'));
+    }
+
+    /**
      * @see https://github.com/mtdowling/cron-expression/issues/47
      */
     public function testIssue47() {


### PR DESCRIPTION
Using L to find the last given weekday of a month passes validation but fails on resolving the next run date if weekday literals are used. E.g expression `* * * * FRIL` is considered valid but will fail because of an infinite loop.

This is regression caused by changes to literal conversion. Current implementation checks for whole matches and weekday ending with L will not be converted while the old implementation replaced matching substrings with numbers regardless. As a result, the `isSatisfiedBy` method ends up in an infinite loop trying to find a date where "FRI" is equal to an integer representation of a weekday which never happens.

Proposed change reruns literal conversion on a substring without L once it is clear that last weekday of the month check will be done.