### PR TITLE
Add PHP7.x primitive type hints to method declaration

### DIFF
--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -45,7 +45,7 @@ abstract class AbstractField implements FieldInterface
      *
      * @return bool
      */
-    public function isSatisfied($dateValue, $value)
+    public function isSatisfied(String $dateValue, String $value)
     {
         if ($this->isIncrementsOfRanges($value)) {
             return $this->isInIncrementsOfRanges($dateValue, $value);
@@ -63,7 +63,7 @@ abstract class AbstractField implements FieldInterface
      *
      * @return bool
      */
-    public function isRange($value)
+    public function isRange(String $value)
     {
         return strpos($value, '-') !== false;
     }
@@ -110,7 +110,7 @@ abstract class AbstractField implements FieldInterface
      *
      * @return bool
      */
-    public function isInIncrementsOfRanges($dateValue, $value)
+    public function isInIncrementsOfRanges(String $dateValue, String $value)
     {
         $chunks = array_map('trim', explode('/', $value, 2));
         $range = $chunks[0];
@@ -157,7 +157,7 @@ abstract class AbstractField implements FieldInterface
      *
      * @return array
      */
-    public function getRangeForExpression($expression, $max)
+    public function getRangeForExpression(String $expression, int $max)
     {
         $values = array();
         $expression = $this->convertLiterals($expression);
@@ -204,7 +204,7 @@ abstract class AbstractField implements FieldInterface
         return $values;
     }
 
-    protected function convertLiterals($value)
+    protected function convertLiterals(String $value)
     {
         if (count($this->literals)) {
             $key = array_search($value, $this->literals);
@@ -222,7 +222,7 @@ abstract class AbstractField implements FieldInterface
      * @param string $value
      * @return bool
      */
-    public function validate($value)
+    public function validate(String $value)
     {
         $value = $this->convertLiterals($value);
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -66,7 +66,7 @@ class CronExpression
      *
      * @return CronExpression
      */
-    public static function factory($expression, FieldFactory $fieldFactory = null)
+    public static function factory(String $expression, FieldFactory $fieldFactory = null)
     {
         $mappings = array(
             '@yearly' => '0 0 1 1 *',
@@ -92,7 +92,7 @@ class CronExpression
      * @return bool True if a valid CRON expression was passed. False if not.
      * @see \Cron\CronExpression::factory
      */
-    public static function isValidExpression($expression)
+    public static function isValidExpression(String $expression)
     {
         try {
             self::factory($expression);
@@ -109,7 +109,7 @@ class CronExpression
      * @param string       $expression   CRON expression (e.g. '8 * * * *')
      * @param FieldFactory|null $fieldFactory Factory to create cron fields
      */
-    public function __construct($expression, FieldFactory $fieldFactory = null)
+    public function __construct(String $expression, FieldFactory $fieldFactory = null)
     {
         $this->fieldFactory = $fieldFactory;
         $this->setExpression($expression);
@@ -123,7 +123,7 @@ class CronExpression
      * @return CronExpression
      * @throws \InvalidArgumentException if not a valid CRON expression
      */
-    public function setExpression($value)
+    public function setExpression(String $value)
     {
         $this->cronParts = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
         if (count($this->cronParts) < 5) {
@@ -148,7 +148,7 @@ class CronExpression
      * @return CronExpression
      * @throws \InvalidArgumentException if the value is not valid for the part
      */
-    public function setPart($position, $value)
+    public function setPart(int $position, String $value)
     {
         if (!$this->fieldFactory->getField($position)->validate($value)) {
             throw new InvalidArgumentException(
@@ -168,7 +168,7 @@ class CronExpression
      *
      * @return CronExpression
      */
-    public function setMaxIterationCount($maxIterationCount)
+    public function setMaxIterationCount(int $maxIterationCount)
     {
         $this->maxIterationCount = $maxIterationCount;
 
@@ -192,7 +192,7 @@ class CronExpression
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
      */
-    public function getNextRunDate($currentTime = 'now', $nth = 0, $allowCurrentDate = false, $timeZone = null)
+    public function getNextRunDate($currentTime = 'now', int $nth = 0, bool $allowCurrentDate = false, $timeZone = null)
     {
         return $this->getRunDate($currentTime, $nth, false, $allowCurrentDate, $timeZone);
     }
@@ -210,7 +210,7 @@ class CronExpression
      * @throws \RuntimeException on too many iterations
      * @see \Cron\CronExpression::getNextRunDate
      */
-    public function getPreviousRunDate($currentTime = 'now', $nth = 0, $allowCurrentDate = false, $timeZone = null)
+    public function getPreviousRunDate($currentTime = 'now', int $nth = 0, bool $allowCurrentDate = false, $timeZone = null)
     {
         return $this->getRunDate($currentTime, $nth, true, $allowCurrentDate, $timeZone);
     }
@@ -227,7 +227,7 @@ class CronExpression
      *
      * @return array Returns an array of run dates
      */
-    public function getMultipleRunDates($total, $currentTime = 'now', $invert = false, $allowCurrentDate = false, $timeZone = null)
+    public function getMultipleRunDates(int $total, $currentTime = 'now', bool $invert = false, bool $allowCurrentDate = false, $timeZone = null)
     {
         $matches = array();
         for ($i = 0; $i < max(0, $total); $i++) {
@@ -319,7 +319,7 @@ class CronExpression
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
      */
-    protected function getRunDate($currentTime = null, $nth = 0, $invert = false, $allowCurrentDate = false, $timeZone = null)
+    protected function getRunDate($currentTime = null, int $nth = 0, bool $invert = false, bool $allowCurrentDate = false, $timeZone = null)
     {
         $timeZone = $this->determineTimeZone($currentTime, $timeZone);
 

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -36,7 +36,7 @@ class DayOfMonthField extends AbstractField
      *
      * @return \DateTime Returns the nearest date
      */
-    private static function getNearestWeekday($currentYear, $currentMonth, $targetDay)
+    private static function getNearestWeekday(int $currentYear, int $currentMonth, int $targetDay)
     {
         $tday = str_pad($targetDay, 2, '0', STR_PAD_LEFT);
         $target = DateTime::createFromFormat('Y-m-d', "$currentYear-$currentMonth-$tday");
@@ -59,7 +59,7 @@ class DayOfMonthField extends AbstractField
         }
     }
 
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, String $value)
     {
         // ? states that the field value is to be skipped
         if ($value == '?') {
@@ -88,7 +88,7 @@ class DayOfMonthField extends AbstractField
         return $this->isSatisfied($date->format('d'), $value);
     }
 
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTime $date, bool $invert = false)
     {
         if ($invert) {
             $date->modify('previous day');
@@ -104,7 +104,7 @@ class DayOfMonthField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function validate($value)
+    public function validate(String $value)
     {
         $basicChecks = parent::validate($value);
 

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -34,7 +34,7 @@ class DayOfWeekField extends AbstractField
         parent::__construct();
     }
 
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, String $value)
     {
         if ($value == '?') {
             return true;
@@ -129,7 +129,7 @@ class DayOfWeekField extends AbstractField
         return $this->isSatisfied($fieldValue, $value);
     }
 
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTime $date, bool $invert = false)
     {
         if ($invert) {
             $date->modify('-1 day');
@@ -145,7 +145,7 @@ class DayOfWeekField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function validate($value)
+    public function validate(String $value)
     {
         $basicChecks = parent::validate($value);
 

--- a/src/Cron/FieldFactory.php
+++ b/src/Cron/FieldFactory.php
@@ -23,7 +23,7 @@ class FieldFactory
      * @return FieldInterface
      * @throws InvalidArgumentException if a position is not valid
      */
-    public function getField($position)
+    public function getField(int $position)
     {
         if (!isset($this->fields[$position])) {
             switch ($position) {

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -16,7 +16,7 @@ interface FieldInterface
      *
      * @return bool Returns TRUE if satisfied, FALSE otherwise
      */
-    public function isSatisfiedBy(DateTime $date, $value);
+    public function isSatisfiedBy(DateTime $date, String $value);
 
     /**
      * When a CRON expression is not satisfied, this method is used to increment
@@ -27,7 +27,7 @@ interface FieldInterface
      *
      * @return FieldInterface
      */
-    public function increment(DateTime $date, $invert = false);
+    public function increment(DateTime $date, bool $invert = false);
 
     /**
      * Validates a CRON expression for a given field
@@ -36,5 +36,5 @@ interface FieldInterface
      *
      * @return bool Returns TRUE if valid, FALSE otherwise
      */
-    public function validate($value);
+    public function validate(String $value);
 }

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -13,12 +13,12 @@ class HoursField extends AbstractField
     protected $rangeStart = 0;
     protected $rangeEnd = 23;
 
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, String $value)
     {
         return $this->isSatisfied($date->format('H'), $value);
     }
 
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTime $date, bool $invert = false, $parts = null)
     {
         // Change timezone to UTC temporarily. This will
         // allow us to go back or forwards and hour even

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -13,12 +13,12 @@ class MinutesField extends AbstractField
     protected $rangeStart = 0;
     protected $rangeEnd = 59;
 
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, String $value)
     {
         return $this->isSatisfied($date->format('i'), $value);
     }
 
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTime $date, bool $invert = false, $parts = null)
     {
         if (is_null($parts)) {
             if ($invert) {

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -14,14 +14,14 @@ class MonthField extends AbstractField
     protected $literals = [1 => 'JAN', 2 => 'FEB', 3 => 'MAR', 4 => 'APR', 5 => 'MAY', 6 => 'JUN', 7 => 'JUL',
         8 => 'AUG', 9 => 'SEP', 10 => 'OCT', 11 => 'NOV', 12 => 'DEC'];
 
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, String $value)
     {
         $value = $this->convertLiterals($value);
 
         return $this->isSatisfied($date->format('m'), $value);
     }
 
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTime $date, bool $invert = false)
     {
         if ($invert) {
             $date->modify('last day of previous month');


### PR DESCRIPTION
The library supports all PHP Versions `>=7.0.0` according to the composer.json. That's why this PR adds strict scalar type hints to the methods that are currently defined in the `src` folder.
I added the types according to the DocBlock of each function.

Feedback is much appreciated :tada:  