### PR TITLE
Support DateTimeImmutable

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -179,16 +179,17 @@ class CronExpression
     /**
      * Get a next run date relative to the current date or a specific date
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning a
-     *                                           matching next run date.  0, the default, will return the current
-     *                                           date and time if the next run date falls on the current date and
-     *                                           time.  Setting this value to 1 will skip the first match and go to
-     *                                           the second match.  Setting this value to 2 will skip the first 2
-     *                                           matches and so on.
-     * @param bool             $allowCurrentDate Set to TRUE to return the current date if
-     *                                           it matches the cron expression.
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param int                       $nth              Number of matches to skip before returning a
+     *                                                    matching next run date.  0, the default, will return the
+     *                                                    current date and time if the next run date falls on the
+     *                                                    current date and time.  Setting this value to 1 will
+     *                                                    skip the first match and go to the second match.
+     *                                                    Setting this value to 2 will skip the first 2
+     *                                                    matches and so on.
+     * @param bool                      $allowCurrentDate Set to TRUE to return the current date if
+     *                                                    it matches the cron expression.
+     * @param null|string               $timeZone         TimeZone to use instead of the system default
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
@@ -201,11 +202,11 @@ class CronExpression
     /**
      * Get a previous run date relative to the current date or a specific date
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param int                       $nth              Number of matches to skip before returning
+     * @param bool                      $allowCurrentDate Set to TRUE to return the
+     *                                                    current date if it matches the cron expression
+     * @param null|string               $timeZone         TimeZone to use instead of the system default
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
@@ -219,14 +220,14 @@ class CronExpression
     /**
      * Get multiple run dates starting at the current date or a specific date
      *
-     * @param int              $total            Set the total number of dates to calculate
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param bool             $invert           Set to TRUE to retrieve previous dates
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param int                       $total            Set the total number of dates to calculate
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param bool                      $invert           Set to TRUE to retrieve previous dates
+     * @param bool                      $allowCurrentDate Set to TRUE to return the
+     *                                                    current date if it matches the cron expression
+     * @param null|string               $timeZone         TimeZone to use instead of the system default
      *
-     * @return array Returns an array of run dates
+     * @return \DateTime[] Returns an array of run dates
      */
     public function getMultipleRunDates($total, $currentTime = 'now', $invert = false, $allowCurrentDate = false, $timeZone = null)
     {
@@ -277,8 +278,8 @@ class CronExpression
      * specific date.  This method assumes that the current number of
      * seconds are irrelevant, and should be called once per minute.
      *
-     * @param string|\DateTime $currentTime Relative calculation date
-     * @param null|string      $timeZone    TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime Relative calculation date
+     * @param null|string               $timeZone    TimeZone to use instead of the system default
      *
      * @return bool Returns TRUE if the cron is due to run or FALSE if not
      */
@@ -310,12 +311,12 @@ class CronExpression
     /**
      * Get the next or previous run date of the expression relative to a date
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning
-     * @param bool             $invert           Set to TRUE to go backwards in time
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param string|null      $timeZone         TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param int                       $nth              Number of matches to skip before returning
+     * @param bool                      $invert           Set to TRUE to go backwards in time
+     * @param bool                      $allowCurrentDate Set to TRUE to return the
+     *                                                    current date if it matches the cron expression
+     * @param string|null               $timeZone         TimeZone to use instead of the system default
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -3,6 +3,7 @@
 namespace Cron;
 
 use DateTime;
+use DateTimeInterface;
 
 /**
  * Day of month field.  Allows: * , / - ? L W
@@ -69,7 +70,7 @@ class DayOfMonthField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
         // ? states that the field value is to be skipped
         if ($value == '?') {
@@ -100,15 +101,15 @@ class DayOfMonthField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable &$date
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTimeInterface &$date, $invert = false)
     {
         if ($invert) {
-            $date->modify('previous day');
-            $date->setTime(23, 59);
+            $date = $date->modify('previous day')->setTime(23, 59);
         } else {
-            $date->modify('next day');
-            $date->setTime(0, 0);
+            $date = $date->modify('next day')->setTime(0, 0);
         }
 
         return $this;

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -3,6 +3,7 @@
 namespace Cron;
 
 use DateTime;
+use DateTimeInterface;
 use InvalidArgumentException;
 
 /**
@@ -51,8 +52,10 @@ class DayOfWeekField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable $date
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
         if ($value == '?') {
             return true;
@@ -71,7 +74,7 @@ class DayOfWeekField extends AbstractField
             $weekday = str_replace('7', '0', $weekday);
 
             $tdate = clone $date;
-            $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
+            $tdate = $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
             while ($tdate->format('w') != $weekday) {
                 $tdateClone = new DateTime();
                 $tdate = $tdateClone
@@ -114,7 +117,7 @@ class DayOfWeekField extends AbstractField
             }
 
             $tdate = clone $date;
-            $tdate->setDate($currentYear, $currentMonth, 1);
+            $tdate = $tdate->setDate($currentYear, $currentMonth, 1);
             $dayCount = 0;
             $currentDay = 1;
             while ($currentDay < $lastDayOfMonth + 1) {
@@ -123,7 +126,7 @@ class DayOfWeekField extends AbstractField
                         break;
                     }
                 }
-                $tdate->setDate($currentYear, $currentMonth, ++$currentDay);
+                $tdate = $tdate->setDate($currentYear, $currentMonth, ++$currentDay);
             }
 
             return $date->format('j') == $currentDay;
@@ -149,15 +152,15 @@ class DayOfWeekField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable &$date
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTimeInterface &$date, $invert = false)
     {
         if ($invert) {
-            $date->modify('-1 day');
-            $date->setTime(23, 59, 0);
+            $date = $date->modify('-1 day')->setTime(23, 59, 0);
         } else {
-            $date->modify('+1 day');
-            $date->setTime(0, 0, 0);
+            $date = $date->modify('+1 day')->setTime(0, 0, 0);
         }
 
         return $this;

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * CRON field interface
@@ -12,23 +12,23 @@ interface FieldInterface
     /**
      * Check if the respective value of a DateTime field satisfies a CRON exp
      *
-     * @param DateTime $date  DateTime object to check
-     * @param string   $value CRON expression to test against
+     * @param DateTimeInterface $date  DateTime object to check
+     * @param string            $value CRON expression to test against
      *
      * @return bool Returns TRUE if satisfied, FALSE otherwise
      */
-    public function isSatisfiedBy(DateTime $date, $value);
+    public function isSatisfiedBy(DateTimeInterface $date, $value);
 
     /**
      * When a CRON expression is not satisfied, this method is used to increment
      * or decrement a DateTime object by the unit of the cron field
      *
-     * @param DateTime $date   DateTime object to change
-     * @param bool     $invert (optional) Set to TRUE to decrement
+     * @param DateTimeInterface &$date  DateTime object to change
+     * @param bool              $invert (optional) Set to TRUE to decrement
      *
      * @return FieldInterface
      */
-    public function increment(DateTime $date, $invert = false);
+    public function increment(DateTimeInterface &$date, $invert = false);
 
     /**
      * Validates a CRON expression for a given field

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 
 /**
@@ -23,32 +23,33 @@ class HoursField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
+        if ($value == '?') {
+            return true;
+        }
+
         return $this->isSatisfied($date->format('H'), $value);
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param string|null $parts
+     * @param \DateTime|\DateTimeImmutable &$date
+     * @param string|null                  $parts
      */
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTimeInterface &$date, $invert = false, $parts = null)
     {
         // Change timezone to UTC temporarily. This will
         // allow us to go back or forwards and hour even
         // if DST will be changed between the hours.
         if (is_null($parts) || $parts == '*') {
             $timezone = $date->getTimezone();
-            $date->setTimezone(new DateTimeZone('UTC'));
-            if ($invert) {
-                $date->modify('-1 hour');
-            } else {
-                $date->modify('+1 hour');
-            }
-            $date->setTimezone($timezone);
+            $date = $date->setTimezone(new DateTimeZone('UTC'));
+            $date = $date->modify(($invert ? '-' : '+') . '1 hour');
+            $date = $date->setTimezone($timezone);
 
-            $date->setTime($date->format('H'), $invert ? 59 : 0);
+            $date = $date->setTime($date->format('H'), $invert ? 59 : 0);
             return $this;
         }
 
@@ -72,11 +73,11 @@ class HoursField extends AbstractField
 
         $hour = $hours[$position];
         if ((!$invert && $date->format('H') >= $hour) || ($invert && $date->format('H') <= $hour)) {
-            $date->modify(($invert ? '-' : '+') . '1 day');
-            $date->setTime($invert ? 23 : 0, $invert ? 59 : 0);
+            $date = $date->modify(($invert ? '-' : '+') . '1 day');
+            $date = $date->setTime($invert ? 23 : 0, $invert ? 59 : 0);
         }
         else {
-            $date->setTime($hour, $invert ? 59 : 0);
+            $date = $date->setTime($hour, $invert ? 59 : 0);
         }
 
         return $this;

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * Minutes field.  Allows: * , / -
@@ -22,24 +22,25 @@ class MinutesField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
+        if ($value == '?') {
+            return true;
+        }
+
         return $this->isSatisfied($date->format('i'), $value);
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param string|null $parts
+     * @param \DateTime|\DateTimeImmutable &$date
+     * @param string|null                  $parts
      */
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTimeInterface &$date, $invert = false, $parts = null)
     {
         if (is_null($parts)) {
-            if ($invert) {
-                $date->modify('-1 minute');
-            } else {
-                $date->modify('+1 minute');
-            }
+            $date = $date->modify(($invert ? '-' : '+') . '1 minute');
             return $this;
         }
 
@@ -62,11 +63,11 @@ class MinutesField extends AbstractField
         }
 
         if ((!$invert && $current_minute >= $minutes[$position]) || ($invert && $current_minute <= $minutes[$position])) {
-            $date->modify(($invert ? '-' : '+') . '1 hour');
-            $date->setTime($date->format('H'), $invert ? 59 : 0);
+            $date = $date->modify(($invert ? '-' : '+') . '1 hour');
+            $date = $date->setTime($date->format('H'), $invert ? 59 : 0);
         }
         else {
-            $date->setTime($date->format('H'), $minutes[$position]);
+            $date = $date->setTime($date->format('H'), $minutes[$position]);
         }
 
         return $this;

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * Month field.  Allows: * , / -
@@ -28,8 +28,12 @@ class MonthField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
+        if ($value == '?') {
+            return true;
+        }
+
         $value = $this->convertLiterals($value);
 
         return $this->isSatisfied($date->format('m'), $value);
@@ -37,15 +41,15 @@ class MonthField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable &$date
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTimeInterface &$date, $invert = false)
     {
         if ($invert) {
-            $date->modify('last day of previous month');
-            $date->setTime(23, 59);
+            $date = $date->modify('last day of previous month')->setTime(23, 59);
         } else {
-            $date->modify('first day of next month');
-            $date->setTime(0, 0);
+            $date = $date->modify('first day of next month')->setTime(0, 0);
         }
 
         return $this;

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -5,6 +5,7 @@ namespace Cron\Tests;
 use Cron\CronExpression;
 use Cron\MonthField;
 use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -228,6 +229,7 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($cron->isDue('now'));
         $this->assertTrue($cron->isDue(new DateTime('now')));
         $this->assertTrue($cron->isDue(date('Y-m-d H:i')));
+        $this->assertTrue($cron->isDue(new DateTimeImmutable('now')));
     }
 
     /**
@@ -405,6 +407,18 @@ class CronExpressionTest extends TestCase
         $this->assertEquals($nextRun, new DateTime("2008-11-23 00:00:00"));
         $nextRun = $cron->getNextRunDate("2008-11-09 00:00:00", 3, true);
         $this->assertEquals($nextRun, new DateTime("2008-11-30 00:00:00"));
+    }
+
+    /**
+     * @covers \Cron\CronExpression::getRunDate
+     */
+    public function testGetRunDateHandlesDifferentDates()
+    {
+        $cron = CronExpression::factory('@weekly');
+        $date = new DateTime("2019-03-10 00:00:00");
+        $this->assertEquals($date, $cron->getNextRunDate("2019-03-03 08:00:00"));
+        $this->assertEquals($date, $cron->getNextRunDate(new DateTime("2019-03-03 08:00:00")));
+        $this->assertEquals($date, $cron->getNextRunDate(new DateTimeImmutable("2019-03-03 08:00:00")));
     }
 
     /**

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\DayOfMonthField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +34,7 @@ class DayOfMonthFieldTest extends TestCase
     {
         $f = new DayOfMonthField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
     }
 
     /**
@@ -48,6 +50,17 @@ class DayOfMonthFieldTest extends TestCase
         $d = new DateTime('2011-03-15 11:15:00');
         $f->increment($d, true);
         $this->assertSame('2011-03-14 23:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\DayOfMonthField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new DayOfMonthField();
+        $f->increment($d);
+        $this->assertSame('2011-03-16 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\DayOfWeekField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +34,7 @@ class DayOfWeekFieldTest extends TestCase
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
     }
 
     /**
@@ -48,6 +50,17 @@ class DayOfWeekFieldTest extends TestCase
         $d = new DateTime('2011-03-15 11:15:00');
         $f->increment($d, true);
         $this->assertSame('2011-03-14 23:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\DayOfWeekField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new DayOfWeekField();
+        $f->increment($d);
+        $this->assertSame('2011-03-16 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\HoursField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +23,17 @@ class HoursFieldTest extends TestCase
         $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
-     }
+    }
+
+    /**
+     * @covers \Cron\HoursField::isSatisfiedBy
+     */
+    public function testChecksIfSatisfied()
+    {
+        $f = new HoursField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+    }
 
     /**
      * @covers \Cron\HoursField::increment
@@ -37,6 +48,17 @@ class HoursFieldTest extends TestCase
         $d->setTime(11, 15, 0);
         $f->increment($d, true);
         $this->assertSame('2011-03-15 10:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\HoursField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new HoursField();
+        $f->increment($d);
+        $this->assertSame('2011-03-15 12:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\MinutesField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,6 +24,16 @@ class MinutesFieldTest extends TestCase
     }
 
     /**
+     * @covers \Cron\MinutesField::isSatisfiedBy
+     */
+    public function testChecksIfSatisfied()
+    {
+        $f = new MinutesField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+    }
+
+    /**
      * @covers \Cron\MinutesField::increment
      */
     public function testIncrementsDate()
@@ -33,6 +44,17 @@ class MinutesFieldTest extends TestCase
         $this->assertSame('2011-03-15 11:16:00', $d->format('Y-m-d H:i:s'));
         $f->increment($d, true);
         $this->assertSame('2011-03-15 11:15:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\MinutesField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new MinutesField();
+        $f->increment($d);
+        $this->assertSame('2011-03-15 11:16:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\MonthField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,6 +25,16 @@ class MonthFieldTest extends TestCase
     }
 
     /**
+     * @covers \Cron\MonthField::isSatisfiedBy
+     */
+    public function testChecksIfSatisfied()
+    {
+        $f = new MonthField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+    }
+
+    /**
      * @covers \Cron\MonthField::increment
      */
     public function testIncrementsDate()
@@ -36,6 +47,17 @@ class MonthFieldTest extends TestCase
         $d = new DateTime('2011-03-15 11:15:00');
         $f->increment($d, true);
         $this->assertSame('2011-02-28 23:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\MonthField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new MonthField();
+        $f->increment($d);
+        $this->assertSame('2011-04-01 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**


### PR DESCRIPTION
Allow `DateTimeImmutable` to be passed as arguments wherever `DateTime` is currently allowed. Logical continuation of #26 