### PR TITLE
Handle invalid numeric ranges

### DIFF
--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -250,6 +250,11 @@ abstract class AbstractField implements FieldInterface
         if (false !== strpos($value, '/')) {
             [$range, $step] = explode('/', $value);
 
+            // Don't allow numeric ranges
+            if (is_numeric($range)) {
+                return false;
+            }
+
             return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
         }
 

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -25,6 +25,7 @@ class HoursFieldTest extends TestCase
         $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
+        $this->assertFalse($f->validate('1/10'));
     }
 
         /**

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -23,6 +23,7 @@ class MinutesFieldTest extends TestCase
         $this->assertTrue($f->validate('1'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
+        $this->assertFalse($f->validate('1/10'));
     }
 
     /**

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -24,6 +24,7 @@ class MonthFieldTest extends TestCase
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/10,2,1-12'));
         $this->assertFalse($f->validate('1.fix-regexp'));
+        $this->assertFalse($f->validate('1/10'));
     }
 
     /**


### PR DESCRIPTION
This evaluates numeric field ranges as invalid.
For example to create expression that is run in 10 minute interval with 1 minute offset:

- Invalid: `1/10 * * * *`
- Valid: `1-59/10 * * * *`

ATM expression above is evaluated to be due only once per hour (hh:01)

Fixes #44 