### PR TITLE
Fix constructor optional argument

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -115,7 +115,7 @@ class CronExpression
      */
     public function __construct(string $expression, FieldFactory $fieldFactory = null)
     {
-        $this->fieldFactory = $fieldFactory;
+        $this->fieldFactory = $fieldFactory ?: new FieldFactory();
         $this->setExpression($expression);
     }
 


### PR DESCRIPTION
When using the `CronExpression` constructor, passing `null` for `$fieldFactory` will result in an unusable object as the fieldFactory is required. This pull request fixes this issue.

But I'd like to ask one question: why do we have a `factory()` method? I don't see the need as everything could be done in the constructor instead. Having 2 ways of creating a `CronExpression` also means that you cannot use shortcuts such as `@daily` when using the constructor. What about removing/deprecating the `factory()` method and move the logic to the constructor instead?
