### PR TITLE
Fix issue with timezones

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -312,7 +312,7 @@ class CronExpression
         $currentTime->setTimezone(new DateTimeZone($timeZone));
 
         // drop the seconds to 0
-        $currentTime = DateTime::createFromFormat('Y-m-d H:i', $currentTime->format('Y-m-d H:i'));
+        $currentTime->setTime((int) $currentTime->format('H'), (int) $currentTime->format('i'), 0);
 
         try {
             return $this->getNextRunDate($currentTime, 0, true)->getTimestamp() === $currentTime->getTimestamp();


### PR DESCRIPTION
The current implementation of "dropping seconds" might lead to a timezone issue as the new date will have UTC. Instead of passing the timezone, I propose to use `setTime()` which seems more appropriate (and used elsewhere in the code base).
