### PR TITLE
Fix cloning dates in isDue()

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -303,7 +303,7 @@ class CronExpression
         if ('now' === $currentTime) {
             $currentTime = new DateTime();
         } elseif ($currentTime instanceof DateTime) {
-            //
+            $currentTime = clone $currentTime;
         } elseif ($currentTime instanceof DateTimeImmutable) {
             $currentTime = DateTime::createFromFormat('U', $currentTime->format('U'));
         } else {


### PR DESCRIPTION
The `isDue()` method clones the given date except when it's a `DateTime` instance. As we are modifying the date, I think we should clone it.
