### PR TITLE
Fix issue #53 - Error calculating next run. Always increment of minutes.

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -394,8 +394,10 @@ class CronExpression
 
             // Skip this match if needed
             if ((!$allowCurrentDate && $nextRun == $currentDate) || --$nth > -1) {
-                $this->fieldFactory->getField(0)->increment($nextRun, $invert, $parts[0] ?? null);
 
+                //Fix issue #53 - Error calculating next run. Always increment of minutes.
+                //$this->fieldFactory->getField(0)->increment($nextRun, $invert, $parts[0] ?? null);
+                $field->increment($nextRun, $invert, $part);
                 continue;
             }
 


### PR DESCRIPTION
I think there is something wrong with CronExpression.php -> getRunDate at line 380. It seams it would increment always minutes and not considers user cron configuration.