### PR TITLE
Fix issue #53 - Error calculating next run

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -394,8 +394,7 @@ class CronExpression
 
             // Skip this match if needed
             if ((!$allowCurrentDate && $nextRun == $currentDate) || --$nth > -1) {
-                $this->fieldFactory->getField(0)->increment($nextRun, $invert, $parts[0] ?? null);
-
+                $field->increment($nextRun, $invert, $part);
                 continue;
             }
 


### PR DESCRIPTION
Always increment of minutes. This correct the issue and consider the user's cron settings.