### PR TITLE
Add @quarterly

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -61,7 +61,7 @@ class CronExpression
      *                           CRON expression:
      *
      *      `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
-     *      `@quarterly` - Run once a quarter, midnight, Jan. 1, Apr. 1, Jul. 1, Oct. 1 - 0 0 1 */3 *
+     *      `@quarterly` - Run once a quarter, midnight, Jan. 1, Apr. 1, Jul. 1, Oct. 1 - 0 0 1 {@*}3 *
      *      `@monthly` - Run once a month, midnight, first of month - 0 0 1 * *
      *      `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
      *      `@daily` - Run once a day, midnight - 0 0 * * *

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -61,6 +61,7 @@ class CronExpression
      *                           CRON expression:
      *
      *      `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
+     *      `@quarterly` - Run once a quarter, midnight, Jan. 1, Apr. 1, Jul. 1, Oct. 1 - 0 0 1 */3 *
      *      `@monthly` - Run once a month, midnight, first of month - 0 0 1 * *
      *      `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
      *      `@daily` - Run once a day, midnight - 0 0 * * *
@@ -74,6 +75,7 @@ class CronExpression
         $mappings = [
             '@yearly' => '0 0 1 1 *',
             '@annually' => '0 0 1 1 *',
+            '@quarterly' => '0 0 1 */3 *',
             '@monthly' => '0 0 1 * *',
             '@weekly' => '0 0 * * 0',
             '@daily' => '0 0 * * *',

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -190,6 +190,12 @@ class CronExpressionTest extends TestCase
             ['0 1 15 JUL mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-15 01:00:00'), false],
             ['0 1 15 jul mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-15 01:00:00'), false],
             ['@Weekly', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
+            
+            // Test @quarterly
+            ['@quarterly', strtotime('2019-12-02 00:00:00'), strtotime('2020-01-01 00:00:00'), false],
+            ['@quarterly', strtotime('2020-01-01 00:00:00'), strtotime('2020-04-01 00:00:00'), false],
+            ['@quarterly', strtotime('2020-04-01 00:00:00'), strtotime('2020-07-01 00:00:00'), false],
+            ['@quarterly', strtotime('2020-07-01 00:00:00'), strtotime('2020-10-01 00:00:00'), false],
         ];
     }
 

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -193,9 +193,9 @@ class CronExpressionTest extends TestCase
             
             // Test @quarterly
             ['@quarterly', strtotime('2019-12-02 00:00:00'), strtotime('2020-01-01 00:00:00'), false],
-            ['@quarterly', strtotime('2020-01-01 00:00:00'), strtotime('2020-04-01 00:00:00'), false],
-            ['@quarterly', strtotime('2020-04-01 00:00:00'), strtotime('2020-07-01 00:00:00'), false],
-            ['@quarterly', strtotime('2020-07-01 00:00:00'), strtotime('2020-10-01 00:00:00'), false],
+            ['@quarterly', strtotime('2020-01-01 00:00:00'), strtotime('2020-04-01 00:00:00'), true],
+            ['@quarterly', strtotime('2020-04-01 00:00:00'), strtotime('2020-07-01 00:00:00'), true],
+            ['@quarterly', strtotime('2020-07-01 00:00:00'), strtotime('2020-10-01 00:00:00'), true],
         ];
     }
 


### PR DESCRIPTION
This PR adds a new CRON mapping: `@quarterly`

The expression runs every quarter at midnight:
- Jan. 1
- Apr. 1
- Jul. 1
- Oct. 1