### PR TITLE
Added important branch alias back

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
             "Cron\\Tests\\": "tests/Cron/"
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.3-dev"
+        }
+    },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan analyse -l 0 src tests"
     }


### PR DESCRIPTION
This is so composer knows what you mean when you ask for `2.3.*` with dev minimum stability, or something like `^2.0`.