### PR TITLE
Mark this package as replace for mtdowling/cron-expression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
             "Cron\\Tests\\": "tests/Cron/"
         }
     },
+    "replace": {
+        "mtdowling/cron-expression": "^1.0"
+    },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan analyse -l 0 src tests"
     }


### PR DESCRIPTION
Will avoid that both mtdowling/cron-expression and this package is installed parallel in a composer.json. So this will completely replace the old package.