### PR TITLE
Replace deprecated expectedException annotations

### DIFF
--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -50,11 +50,11 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::__construct
      * @covers \Cron\CronExpression::getExpression
      * @covers \Cron\CronExpression::__toString
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid CRON field value A at position 0
      */
     public function testParsesCronScheduleThrowsAnException(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid CRON field value A at position 0');
         CronExpression::factory('A 1 2 3 4');
     }
 
@@ -94,20 +94,20 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::__construct
      * @covers \Cron\CronExpression::setExpression
      * @covers \Cron\CronExpression::setPart
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCronsWillFail(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         // Only four values
         $cron = CronExpression::factory('* * * 1');
     }
 
     /**
      * @covers \Cron\CronExpression::setPart
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidPartsWillFail(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         // Only four values
         $cron = CronExpression::factory('* * * * *');
         $cron->setPart(1, 'abc');

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -7,6 +7,7 @@ namespace Cron\Tests;
 use Cron\DayOfWeekField;
 use DateTime;
 use DateTimeImmutable;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -67,22 +68,22 @@ class DayOfWeekFieldTest extends TestCase
 
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Weekday must be a value between 0 and 7. 12 given
      */
     public function testValidatesHashValueWeekday()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Weekday must be a value between 0 and 7. 12 given');
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '12#1'));
     }
 
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage There are never more than 5 or less than 1 of a given weekday in a month
      */
     public function testValidatesHashValueNth()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There are never more than 5 or less than 1 of a given weekday in a month');
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '3#6'));
     }

--- a/tests/Cron/FieldFactoryTest.php
+++ b/tests/Cron/FieldFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cron\Tests;
 
 use Cron\FieldFactory;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,10 +35,10 @@ class FieldFactoryTest extends TestCase
 
     /**
      * @covers \Cron\FieldFactory::getField
-     * @expectedException \InvalidArgumentException
      */
     public function testValidatesFieldPosition()
     {
+        $this->expectException(InvalidArgumentException::class);
         $f = new FieldFactory();
         $f->getField(-1);
     }


### PR DESCRIPTION
From PHPUnit 8:
> The @expectedException, @expectedExceptionCode,
> @expectedExceptionMessage, and @expectedExceptionMessageRegExp
> annotations are deprecated. They will be removed in PHPUnit 9.
> Refactor your test to use expectException(), expectExceptionCode(),
> expectExceptionMessage(), or expectExceptionMessageRegExp() instead.

This change is compatible with PHPUnit 6.4, the oldest version of currently supported according to the composer.json file.