### PR TITLE
Adds human readable translation to CronExpression per #74

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "lorisleiva/cron-translator": "^0.1.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11",

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -10,6 +10,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
+use Lorisleiva\CronTranslator\CronTranslator;
 use RuntimeException;
 
 /**
@@ -320,6 +321,16 @@ class CronExpression
         } catch (Exception $e) {
             return false;
         }
+    }
+
+    /**
+     * Returns a string containing the english version of the cron expression.
+     *
+     * @return string The english version of the string.
+     */
+    public function asHumanReadable(): string
+    {
+        return CronTranslator::translate($this->getExpression());
     }
 
     /**

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -621,4 +621,22 @@ class CronExpressionTest extends TestCase
 
         $this->assertSame("00", $nextRunDate->format("i"));
     }
+
+    /**
+     * @covers \Cron\CronExpression::asHumanReadable
+     */
+    public function testDisplayCronAsHumanReadable()
+    {
+        $cron = CronExpression::factory('* * * * *');
+        $this->assertSame('Every minute', $cron->asHumanreadable());
+
+        $cron = CronExpression::factory('30 22 * * *');
+        $this->assertSame('Every day at 10:30pm', $cron->asHumanreadable());
+
+        $cron = CronExpression::factory('0 16 * * 1');
+        $this->assertSame('Every Monday at 4:00pm', $cron->asHumanreadable());
+
+        $cron = CronExpression::factory('0 1-5 * * *');
+        $this->assertSame('5 times a day', $cron->asHumanreadable());
+    }
 }


### PR DESCRIPTION
Using the CronTranslator library, CronExpressions can now be turned into
a human readable format with the function `asHumanReadable`.

This would close #74 