### PR TITLE
Allow proper usage of interfaces

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -85,7 +85,7 @@ class CronExpression
             $expression = $mappings[$shortcut];
         }
 
-        return new static($expression, $fieldFactory ?: new FieldFactory());
+        return new static($expression, $fieldFactory);
     }
 
     /**
@@ -112,9 +112,9 @@ class CronExpression
      * Parse a CRON expression.
      *
      * @param string $expression CRON expression (e.g. '8 * * * *')
-     * @param null|FieldFactory $fieldFactory Factory to create cron fields
+     * @param null|FieldFactoryInterface $fieldFactory Factory to create cron fields
      */
-    public function __construct(string $expression, FieldFactory $fieldFactory = null)
+    public function __construct(string $expression, FieldFactoryInterface $fieldFactory = null)
     {
         $this->fieldFactory = $fieldFactory ?: new FieldFactory();
         $this->setExpression($expression);

--- a/src/Cron/FieldFactoryInterface.php
+++ b/src/Cron/FieldFactoryInterface.php
@@ -4,5 +4,5 @@ namespace Cron;
 
 interface FieldFactoryInterface
 {
-    public function getField(int $position);
+    public function getField(int $position): FieldInterface;
 }


### PR DESCRIPTION
The constructor for CronExpression should take a FieldFactoryInterface,
not FieldFactory.
FieldFactoryInterface should return FieldInterface.

I'm aware this is similar to PR #86 but I think this one is more complete.

Would close #97  
Would close #86 