### PR TITLE
Depreceate CronExpression::factory and remove references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ Usage
 require_once '/vendor/autoload.php';
 
 // Works with predefined scheduling definitions
-$cron = Cron\CronExpression::factory('@daily');
+$cron = new Cron\CronExpression('@daily');
 $cron->isDue();
 echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
 echo $cron->getPreviousRunDate()->format('Y-m-d H:i:s');
 
 // Works with complex expressions
-$cron = Cron\CronExpression::factory('3-59/15 6-12 */15 1 2-5');
+$cron = new Cron\CronExpression('3-59/15 6-12 */15 1 2-5');
 echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
 
 // Calculate a run date two iterations into the future
-$cron = Cron\CronExpression::factory('@daily');
+$cron = new Cron\CronExpression('@daily');
 echo $cron->getNextRunDate(null, 2)->format('Y-m-d H:i:s');
 
 // Calculate a run date relative to a specific time
-$cron = Cron\CronExpression::factory('@monthly');
+$cron = new Cron\CronExpression('@monthly');
 echo $cron->getNextRunDate('2010-01-12 00:00:00')->format('Y-m-d H:i:s');
 ```
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -33,6 +33,15 @@ class CronExpression
     public const WEEKDAY = 4;
     public const YEAR = 5;
 
+    public const MAPPINGS = [
+        '@yearly' => '0 0 1 1 *',
+        '@annually' => '0 0 1 1 *',
+        '@monthly' => '0 0 1 * *',
+        '@weekly' => '0 0 * * 0',
+        '@daily' => '0 0 * * *',
+        '@hourly' => '0 * * * *',
+    ];
+
     /**
      * @var array CRON expression parts
      */
@@ -51,41 +60,21 @@ class CronExpression
     /**
      * @var array Order in which to test of cron parts
      */
-    private static $order = [self::YEAR, self::MONTH, self::DAY, self::WEEKDAY, self::HOUR, self::MINUTE];
+    private static $order = [
+        self::YEAR,
+        self::MONTH,
+        self::DAY,
+        self::WEEKDAY,
+        self::HOUR,
+        self::MINUTE,
+    ];
 
     /**
-     * Factory method to create a new CronExpression.
-     *
-     * @param string $expression The CRON expression to create.  There are
-     *                           several special predefined values which can be used to substitute the
-     *                           CRON expression:
-     *
-     *      `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
-     *      `@monthly` - Run once a month, midnight, first of month - 0 0 1 * *
-     *      `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
-     *      `@daily` - Run once a day, midnight - 0 0 * * *
-     *      `@hourly` - Run once an hour, first minute - 0 * * * *
-     * @param null|FieldFactoryInterface $fieldFactory Field factory to use
-     *
-     * @return CronExpression
+     * @deprecated since version 3.0.2, use __construct instead.
      */
     public static function factory(string $expression, FieldFactoryInterface $fieldFactory = null): CronExpression
     {
-        $mappings = [
-            '@yearly' => '0 0 1 1 *',
-            '@annually' => '0 0 1 1 *',
-            '@monthly' => '0 0 1 * *',
-            '@weekly' => '0 0 * * 0',
-            '@daily' => '0 0 * * *',
-            '@hourly' => '0 * * * *',
-        ];
-
-        $shortcut = strtolower($expression);
-        if (isset($mappings[$shortcut])) {
-            $expression = $mappings[$shortcut];
-        }
-
-        return new static($expression, $fieldFactory ?: new FieldFactory());
+        return new static($expression, $fieldFactory);
     }
 
     /**
@@ -94,13 +83,11 @@ class CronExpression
      * @param string $expression the CRON expression to validate
      *
      * @return bool True if a valid CRON expression was passed. False if not.
-     *
-     * @see \Cron\CronExpression::factory
      */
     public static function isValidExpression(string $expression): bool
     {
         try {
-            self::factory($expression);
+            new CronExpression($expression);
         } catch (InvalidArgumentException $e) {
             return false;
         }
@@ -116,6 +103,10 @@ class CronExpression
      */
     public function __construct(string $expression, FieldFactory $fieldFactory = null)
     {
+
+        $shortcut = strtolower($expression);
+        $expression = self::MAPPINGS[$shortcut] ?? $expression;
+
         $this->fieldFactory = $fieldFactory ?: new FieldFactory();
         $this->setExpression($expression);
     }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -103,7 +103,6 @@ class CronExpression
      */
     public function __construct(string $expression, FieldFactory $fieldFactory = null)
     {
-
         $shortcut = strtolower($expression);
         $expression = self::MAPPINGS[$shortcut] ?? $expression;
 


### PR DESCRIPTION
This would close #56 

If needed, we can specify a specific version in which the factory will be removed entirely.