### PR TITLE
Improve instance of assertion

### DIFF
--- a/tests/Cron/FieldFactoryTest.php
+++ b/tests/Cron/FieldFactoryTest.php
@@ -29,7 +29,7 @@ class FieldFactoryTest extends TestCase
         $f = new FieldFactory();
 
         foreach ($mappings as $position => $class) {
-            $this->assertSame($class, \get_class($f->getField($position)));
+            $this->assertInstanceOf($class, $f->getField($position));
         }
     }
 


### PR DESCRIPTION
# Changed log

- Using the `assertInstanceOf` to assert expected instance is same as result.