### PR TITLE
midnight is also an allowed shortcut in crontab

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This library also supports a few macros:
 * `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - `0 0 1 1 *`
 * `@monthly` - Run once a month, midnight, first of month - `0 0 1 * *`
 * `@weekly` - Run once a week, midnight on Sun - `0 0 * * 0`
-* `@daily` - Run once a day, midnight - `0 0 * * *`
+* `@daily`, `@midnight` - Run once a day, midnight - `0 0 * * *`
 * `@hourly` - Run once an hour, first minute - `0 * * * *`
 
 Requirements

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -32,7 +32,7 @@ class CronExpression
     public const DAY = 2;
     public const MONTH = 3;
     public const WEEKDAY = 4;
-    
+
     /** @deprecated */
     public const YEAR = 5;
 
@@ -42,6 +42,7 @@ class CronExpression
         '@monthly' => '0 0 1 * *',
         '@weekly' => '0 0 * * 0',
         '@daily' => '0 0 * * *',
+        '@midnight' => '0 0 * * *',
         '@hourly' => '0 * * * *',
     ];
 

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -26,6 +26,8 @@ class CronExpressionTest extends TestCase
         $this->assertSame('0 0 1 1 *', (new CronExpression('@annually'))->getExpression());
         $this->assertSame('0 0 1 1 *', (new CronExpression('@yearly'))->getExpression());
         $this->assertSame('0 0 * * 0', (new CronExpression('@weekly'))->getExpression());
+        $this->assertSame('0 0 * * *', (new CronExpression('@daily'))->getExpression());
+        $this->assertSame('0 0 * * *', (new CronExpression('@midnight'))->getExpression());
     }
 
     /**


### PR DESCRIPTION
@see https://manpages.debian.org/buster/cron/crontab.5.en.html

this adds the `@midnight` to the mapping which is the same as `@daily`.
But since it is available in some cron implementations it should not be
indicated as invalid.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>