### PR TITLE
Fix getPreviousRunDate return value for cron expression with both day-of-month and day-of-week set

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -393,6 +393,9 @@ class CronExpression
             usort($combined, function ($a, $b) {
                 return $a->format('Y-m-d H:i:s') <=> $b->format('Y-m-d H:i:s');
             });
+            if ($invert) {
+                $combined = array_reverse($combined);
+            }
 
             return $combined[$nth];
         }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -441,6 +441,22 @@ class CronExpressionTest extends TestCase
     }
 
     /**
+     * If both day of month and day of week are set in an expression,
+     * we have to return a date which among dates matching either of two criteria is closest to the current date.
+     *
+     * Previously the earliest of dates was always returned, which was incorrect for previous run date.
+     *
+     * @covers \Cron\CronExpression::getRunDate
+     */
+    public function testGetRunDateHandlesSimultaneousDayOfMonthAndDayOfWeek(): void
+    {
+        $cron = new CronExpression('0 0 13 * 3');
+        $date = new DateTime("2021-07-15 00:00:00");
+        $this->assertEquals(new DateTime("2021-07-21 00:00:00"), $cron->getNextRunDate($date));
+        $this->assertEquals(new DateTime("2021-07-14 00:00:00"), $cron->getPreviousRunDate($date));
+    }
+
+    /**
      * @covers \Cron\CronExpression::getRunDate
      */
     public function testSkipsCurrentDateByDefault(): void


### PR DESCRIPTION
In `\Cron\CronExpression::getRunDate` method, cron expressions with both day-of-month and day-of-week set are detected with special `if (isset($parts[2]) && isset($parts[4]))` check, and treated differently than other patterns. In this execution branch, the expression is treated as two separate expressions with wildcards instead of one of the dwo day parameters. The results are merged and sorted, and after that the corresponding `$nth` result is returned.

However, this method is used internally by both `getNextRunDate` and `getPreviousRunDate` methods of the class, and yet the sorting order is incorrectly the same in both cases, irrespective of the `$invert` parameter passed to the method.

This pull request fixes the bug and adds a test to prevent a future regression.