### PR TITLE
Fix "," delimiter precedence

### DIFF
--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -249,17 +249,6 @@ abstract class AbstractField implements FieldInterface
             return true;
         }
 
-        if (false !== strpos($value, '/')) {
-            [$range, $step] = explode('/', $value);
-
-            // Don't allow numeric ranges
-            if (is_numeric($range)) {
-                return false;
-            }
-
-            return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
-        }
-
         // Validate each chunk of a list individually
         if (false !== strpos($value, ',')) {
             foreach (explode(',', $value) as $listItem) {
@@ -269,6 +258,17 @@ abstract class AbstractField implements FieldInterface
             }
 
             return true;
+        }
+
+        if (false !== strpos($value, '/')) {
+            [$range, $step] = explode('/', $value);
+
+            // Don't allow numeric ranges
+            if (is_numeric($range)) {
+                return false;
+            }
+
+            return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
         }
 
         if (false !== strpos($value, '-')) {

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -137,5 +137,7 @@ class AbstractFieldTest extends TestCase
         $this->assertSame(['5', '6', '7', '11', '12', '13'], $f->getRangeForExpression('5,6,7,11,12,13', 23));
         $this->assertSame([0, 6, 12, 18], $f->getRangeForExpression('*/6', 23));
         $this->assertSame([5, 11], $f->getRangeForExpression('5-13/6', 23));
+        $this->assertSame([1, 2, 3, 4, 11, 13, 21, 24, 27, 40, 50], $f->getRangeForExpression('1-4,11-14/2,21-27/3,40-59/10', 59));
+        $this->assertSame(['1', '3', 5, 6, 7, 11, 12, 13, 14, 15, 17, 19, 21, '23'], $f->getRangeForExpression('1,3,5-7,11-15/1,17-22/2,23', 23));
     }
 }


### PR DESCRIPTION
Thanks to everyone who contributed to this amazing library.
This is my first pull request to an open source project, and I'm ready to learn, open to any comments :)

I had trouble with this library to run cron expressions like `*/3,1,1-12`, `1-30/2,31-59/5 * * * *`.
I found that, according to the assertions in the unit tests, this project regards cron expressions invalid when multiple ranges _and_ step are mixed. However, those expressions seem valid and also pass many online validators.

I switched the handling order of `/` and `,` characters in `\Cron\AbstractField::validate()` method to meet the semantic order of cron expression, and the library now works as expected.

After the code change, existing unit tests that invalidates such expressions now fails.
- \Cron\Tests\HoursFieldTest::testValidatesField `*/3,1,1-12`
- \Cron\Tests\MinutesFieldTest::testValidatesField `*/3,1,1-12`
- \Cron\Tests\MonthFieldTest::testValidatesField `*/10,2,1-12`

If these invalidations are intentional, my fix would be an incorrect one.
Thanks.
