### PR TITLE
Update CronExpression.php

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -390,9 +390,11 @@ class CronExpression
             $dowRunDates = $dowExpression->getMultipleRunDates($nth + 1, $currentTime, $invert, $allowCurrentDate, $timeZone);
 
             $combined = array_merge($domRunDates, $dowRunDates);
-            usort($combined, function ($a, $b) {
-                return $a->format('Y-m-d H:i:s') <=> $b->format('Y-m-d H:i:s');
-            });
+            if ($parts[2] !== 'L') {
+                usort($combined, function ($a, $b) {
+                    return $a->format('Y-m-d H:i:s') <=> $b->format('Y-m-d H:i:s');
+                });
+            }
 
             return $combined[$nth];
         }


### PR DESCRIPTION
If the DayOfMonth is set to L the usort reorders the $combined and then $nth points to the current date instead of the last day of the month.