### PR TITLE
Fix failing PHPStan issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,17 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          args: analyse --level=max src
+          php-version: ${{ matrix.php }}
+          extensions: json, mbstring
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Start Static Analyze
+        run: composer phpstan -n
 
   phpunit:
     name: PHPUnit - PHP ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "mtdowling/cron-expression": "^1.0"
     },
     "scripts": {
-        "phpstan": "./vendor/bin/phpstan analyse -l max src",
+        "phpstan": "./vendor/bin/phpstan analyse -l max src tests",
         "test": "phpunit"
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -636,7 +636,7 @@ class CronExpressionTest extends TestCase
     /**
      * Tests the getParts function.
      */
-    public function testGetParts()
+    public function testGetParts(): void
     {
         $e = CronExpression::factory('0 22 * * 1-5');
         $parts = $e->getParts();


### PR DESCRIPTION
# Changed log

- Removing remote Docker image about `PHPStan`. Using the `composer phpstan` script instead.
- Adding `tests` folder to be analysed via customized `composer phpstan` script.
- Adding the returning `void` type hint to fix following PHPStan issue:

```Bash
peterli@peterli-Virtual-Machine:~/cron-expression$ php ~/composer.phar phpstan -n
For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins
You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.
> ./vendor/bin/phpstan analyse -l max src tests
Note: Using configuration file /home/peterli/cron-expression/phpstan.neon.
 18/18 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------
  Line   tests/Cron/CronExpressionTest.php
 ------ --------------------------------------------------------------------
  639    Method Cron\Tests\CronExpressionTest::testGetParts() has no return
         typehint specified.
 ------ --------------------------------------------------------------------

 [ERROR] Found 1 error

Script ./vendor/bin/phpstan analyse -l max src tests handling the phpstan event returned with error code 1
peterli@peterli-Virtual-Machine:~/cron-expression$
```