### PR TITLE
Adding Registering alias feature to the package

### DIFF
--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -730,16 +730,16 @@ class CronExpressionTest extends TestCase
     {
         CronExpression::registerAlias('@every', '* * * * *');
 
-        self::assertCount(8, CronExpression::aliases());
-        self::assertArrayHasKey('@every', CronExpression::aliases());
+        self::assertCount(8, CronExpression::getAliases());
+        self::assertArrayHasKey('@every', CronExpression::getAliases());
         self::assertTrue(CronExpression::supportsAlias('@every'));
         self::assertEquals(new CronExpression('@every'), new CronExpression('* * * * *'));
 
         self::assertTrue(CronExpression::unregisterAlias('@every'));
         self::assertFalse(CronExpression::unregisterAlias('@every'));
 
-        self::assertCount(7, CronExpression::aliases());
-        self::assertArrayNotHasKey('@every', CronExpression::aliases());
+        self::assertCount(7, CronExpression::getAliases());
+        self::assertArrayNotHasKey('@every', CronExpression::getAliases());
         self::assertFalse(CronExpression::supportsAlias('@every'));
 
         $this->expectException(LogicException::class);

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -680,7 +680,6 @@ class CronExpressionTest extends TestCase
         $this->assertEquals($expected, $next);
     }
 
-
     /**
      * Helps validate additional test cases that were failing as part of #131's fix
      *

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -10,6 +10,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Webmozart\Assert\Assert;
 
@@ -723,5 +724,61 @@ class CronExpressionTest extends TestCase
         $expected = new \DateTime('2021-12-31 20:00:00');
         $prev = $e->getPreviousRunDate(new \DateTime('2022-08-20 03:44:02'), 1);
         $this->assertEquals($expected, $prev);
+    }
+
+    public function testItCanRegisterAnValidExpression(): void
+    {
+        CronExpression::registerAlias('@every', '* * * * *');
+
+        self::assertCount(8, CronExpression::aliases());
+        self::assertArrayHasKey('@every', CronExpression::aliases());
+        self::assertTrue(CronExpression::supportsAlias('@every'));
+        self::assertEquals(new CronExpression('@every'), new CronExpression('* * * * *'));
+
+        self::assertTrue(CronExpression::unregisterAlias('@every'));
+        self::assertFalse(CronExpression::unregisterAlias('@every'));
+
+        self::assertCount(7, CronExpression::aliases());
+        self::assertArrayNotHasKey('@every', CronExpression::aliases());
+        self::assertFalse(CronExpression::supportsAlias('@every'));
+
+        $this->expectException(LogicException::class);
+        new CronExpression('@every');
+    }
+
+    public function testItWillFailToRegisterAnInvalidExpression(): void
+    {
+        $this->expectException(LogicException::class);
+
+        CronExpression::registerAlias('@every', 'foobar');
+    }
+
+    public function testItWillFailToRegisterAnInvalidName(): void
+    {
+        $this->expectException(LogicException::class);
+
+        CronExpression::registerAlias('every', '* * * * *');
+    }
+
+    public function testItWillFailToRegisterAnInvalidName2(): void
+    {
+        $this->expectException(LogicException::class);
+
+        CronExpression::registerAlias('@évery', '* * * * *');
+    }
+
+    public function testItWillFailToRegisterAValidNameTwice(): void
+    {
+        CronExpression::registerAlias('@Ev_eR_y', '* * * * *');
+
+        $this->expectException(LogicException::class);
+        CronExpression::registerAlias('@eV_Er_Y', '2 2 2 2 2');
+    }
+
+    public function testItWillFailToUnregisterADefaultExpression(): void
+    {
+        $this->expectException(LogicException::class);
+
+        CronExpression::unregisterAlias('@daily');
     }
 }


### PR DESCRIPTION
This PR is inspired by my work on [bakame/cron](https://github.com/bakame-php/cron-expression/releases/tag/0.5.0) to resolve #64 

here's the proposed public API:

```php
<?php

use Cron\CronExpression;

if (!CronExpression::supportsAlias('@every')) {
    CronExpression::registerAlias('@every', '* * * * *');
}

CronExpression::getAliases();
// returns
// array (
//   '@yearly' => '0 0 1 1 *',
//   '@annually' => '0 0 1 1 *',
//   '@monthly' => '0 0 1 * *',
//   '@weekly' => '0 0 * * 0',
//   '@daily' => '0 0 * * *',
//   '@midnight' => '0 0 * * *',
//   '@hourly' => '0 * * * *',
//   '@every' => '* * * * *',
// )
CronExpression::supportsAlias('@foobar'); //return false
CronExpression::supportsAlias('@daily');  //return true
CronExpression::supportsAlias('@every');  //return true

$cron = new CronExpression('@every');  // works!
$cron->getExpression(); // return * * * * *

CronExpression::unregisterAlias('@every'); // return true
CronExpression::unregisterAlias('@every'); // return false 
                                           // because on the second time the alias is already removed!

CronExpression::supportsAlias('@every');   //return false

new CronExpression('@every');  //throws InvalidArgumentException unknown or unsupported expression
CronExpression::unregisterAlias('@daily');  //throws LogicException exception
```


Comments and remarks are welcomed.
PS: while running the test as is on PHP8.1 some tests were failing prior to my addition via this PR.