### PR TITLE
#137 Add check for multiple question marks

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -201,21 +201,22 @@ class CronExpression
         $split = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
         Assert::isArray($split);
 
-        $this->cronParts = $split;
-        $multipleQuestionMarks = \count(
-            \array_filter(
-                $this->cronParts,
-                function(string $p): bool {
-                    return $p === '?';
-                }
-            )
-        ) > 1;
-        if (\count($this->cronParts) < 5 || $multipleQuestionMarks) {
+        $notEnoughParts = \count($split) < 5;
+
+        $questionMarkInInvalidPart = array_key_exists(0, $split) && $split[0] === '?'
+            || array_key_exists(1, $split) && $split[1] === '?'
+            || array_key_exists(3, $split) && $split[3] === '?';
+
+        $tooManyQuestionMarks = array_key_exists(2, $split) && $split[2] === '?'
+            && array_key_exists(4, $split) && $split[4] === '?';
+
+        if ($notEnoughParts || $questionMarkInInvalidPart || $tooManyQuestionMarks) {
             throw new InvalidArgumentException(
                 $value . ' is not a valid CRON expression'
             );
         }
 
+        $this->cronParts = $split;
         foreach ($this->cronParts as $position => $part) {
             $this->setPart($position, $part);
         }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -202,7 +202,15 @@ class CronExpression
         Assert::isArray($split);
 
         $this->cronParts = $split;
-        if (\count($this->cronParts) < 5) {
+        $multipleQuestionMarks = \count(
+            \array_filter(
+                $this->cronParts,
+                function(string $p): bool {
+                    return $p === '?';
+                }
+            )
+        ) > 1;
+        if (\count($this->cronParts) < 5 || $multipleQuestionMarks) {
             throw new InvalidArgumentException(
                 $value . ' is not a valid CRON expression'
             );

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -565,6 +565,10 @@ class CronExpressionTest extends TestCase
 
         // Issue #137, multiple question marks are not allowed
         $this->assertFalse(CronExpression::isValidExpression('0 8 ? * ?'));
+        // Question marks are only allowed in dom and dow part
+        $this->assertFalse(CronExpression::isValidExpression('? * * * *'));
+        $this->assertFalse(CronExpression::isValidExpression('* ? * * *'));
+        $this->assertFalse(CronExpression::isValidExpression('* * * ? *'));
 
         // see https://github.com/dragonmantank/cron-expression/issues/5
         $this->assertTrue(CronExpression::isValidExpression('2,17,35,47 5-7,11-13 * * *'));

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -563,6 +563,9 @@ class CronExpressionTest extends TestCase
         // Issue #125, this is just all sorts of wrong
         $this->assertFalse(CronExpression::isValidExpression('990 14 * * mon-fri0345345'));
 
+        // Issue #137, multiple question marks are not allowed
+        $this->assertFalse(CronExpression::isValidExpression('0 8 ? * ?'));
+
         // see https://github.com/dragonmantank/cron-expression/issues/5
         $this->assertTrue(CronExpression::isValidExpression('2,17,35,47 5-7,11-13 * * *'));
     }


### PR DESCRIPTION
This solves #137 

Passing two question marks into a cron expression does not really make sense in my opinion, as you would neither specify the day of month nor the day of week. Wikipedia states

> In some implementations, used instead of '*' for leaving **either** day-of-month **or** day-of-week blank.

I guess, this is the implementation this library is following.

I've also added a check to validate if there are question marks in parts, where they are not allowed. 
Maybe there should be an extra step to validate each part against it's allowed values. What do you think about this?