### PR TITLE
Remove duplicate `/phpstan.neon` entry in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,3 @@
 /.travis.yml export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
-/phpstan.neon export-ignore


### PR DESCRIPTION
This duplicate was not added in alphabetical order and thus probably was missed during PR merge.

see 6dda2176a2e2092a2169bb7bab87046b8758165a