### PR TITLE
Fix skipped next execution hour

### DIFF
--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -139,6 +139,7 @@ class HoursField extends AbstractField
         }
 
         $parts = false !== strpos($parts, ',') ? explode(',', $parts) : [$parts];
+        sort($parts);
         $hours = [];
         foreach ($parts as $part) {
             $hours = array_merge($hours, $this->getRangeForExpression($part, 23));


### PR DESCRIPTION
Similar to this PR: https://github.com/dragonmantank/cron-expression/pull/160.
The next execution hour is skipped when the hours in the cron expression are not sorted. E.g. the schedule at 10 is skipped if the cron expression is `0 20,10 * * *`