### PR TITLE
Fixed backward incompatible change in php8.2

### DIFF
--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -167,37 +167,37 @@ class HoursField extends AbstractField
         if (! $invert) {
             if ($originalHour >= $target) {
                 $distance = 24 - $originalHour;
-                $date = $this->timezoneSafeModify($date, "+{$distance} hours");
+                $date = $this->timezoneSafeModify($date, "{$distance} hours");
 
                 $actualDay = (int)$date->format('d');
                 $actualHour = (int)$date->format('H');
                 if (($actualDay !== ($originalDay + 1)) && ($actualHour !== 0)) {
                     $offsetChange = ($previousOffset - $date->getOffset());
-                    $date = $this->timezoneSafeModify($date, "+{$offsetChange} seconds");
+                    $date = $this->timezoneSafeModify($date, "{$offsetChange} seconds");
                 }
 
                 $originalHour = (int)$date->format('H');
             }
 
             $distance = $target - $originalHour;
-            $date = $this->timezoneSafeModify($date, "+{$distance} hours");
+            $date = $this->timezoneSafeModify($date, "{$distance} hours");
         } else {
             if ($originalHour <= $target) {
                 $distance = ($originalHour + 1);
-                $date = $this->timezoneSafeModify($date, "-" . $distance . " hours");
+                $date = $this->timezoneSafeModify($date, (-$distance) . " hours");
 
                 $actualDay = (int)$date->format('d');
                 $actualHour = (int)$date->format('H');
                 if (($actualDay !== ($originalDay - 1)) && ($actualHour !== 23)) {
                     $offsetChange = ($previousOffset - $date->getOffset());
-                    $date = $this->timezoneSafeModify($date, "+{$offsetChange} seconds");
+                    $date = $this->timezoneSafeModify($date, "{$offsetChange} seconds");
                 }
 
                 $originalHour = (int)$date->format('H');
             }
 
             $distance = $originalHour - $target;
-            $date = $this->timezoneSafeModify($date, "-{$distance} hours");
+            $date = $this->timezoneSafeModify($date, (-$distance) . " hours");
         }
 
         $date = $this->setTimeHour($date, $invert, $originalTimestamp);

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -73,23 +73,23 @@ class MinutesField extends AbstractField
         if (! $invert) {
             if ($originalMinute >= $target) {
                 $distance = 60 - $originalMinute;
-                $date = $this->timezoneSafeModify($date, "+{$distance} minutes");
+                $date = $this->timezoneSafeModify($date, "{$distance} minutes");
 
                 $originalMinute = (int) $date->format("i");
             }
 
             $distance = $target - $originalMinute;
-            $date = $this->timezoneSafeModify($date, "+{$distance} minutes");
+            $date = $this->timezoneSafeModify($date, "{$distance} minutes");
         } else {
             if ($originalMinute <= $target) {
                 $distance = ($originalMinute + 1);
-                $date = $this->timezoneSafeModify($date, "-{$distance} minutes");
+                $date = $this->timezoneSafeModify($date, (-$distance) . " minutes");
 
                 $originalMinute = (int) $date->format("i");
             }
 
             $distance = $originalMinute - $target;
-            $date = $this->timezoneSafeModify($date, "-{$distance} minutes");
+            $date = $this->timezoneSafeModify($date, (-$distance) . " minutes");
         }
 
         return $this;

--- a/tests/Cron/DaylightSavingsTest.php
+++ b/tests/Cron/DaylightSavingsTest.php
@@ -453,4 +453,32 @@ class DaylightSavingsTest extends TestCase
             $this->assertContainsEquals($dtExpected, $actual);
         }
     }
+
+    public function testOffsetIncrementDailyMidnight(): void
+    {
+        $expression = '15 0 * * *';
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("America/Los_Angeles");
+
+        $expected = [
+            $this->createDateTimeExactly("2024-03-08 00:15-08:00", $tz),
+            $this->createDateTimeExactly("2024-03-09 00:15-08:00", $tz),
+            $this->createDateTimeExactly("2024-03-10 00:15-08:00", $tz),
+            $this->createDateTimeExactly("2024-03-11 00:15-07:00", $tz),
+            $this->createDateTimeExactly("2024-03-12 00:15-07:00", $tz),
+            $this->createDateTimeExactly("2024-03-13 00:15-07:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2024-03-08 00:15-08:00", $tz);
+        $actual = $cron->getMultipleRunDates(6, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $dtCurrent = $this->createDateTimeExactly("2024-03-13 00:15-07:00", $tz);
+        $actual = $cron->getMultipleRunDates(6, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+    }
 }


### PR DESCRIPTION
php8.2 has backward incompatible: number symbols in relative formats no longer accept multiple signs, e.g. +-2.

https://www.php.net/manual/en/migration82.incompatible.php