### PR TITLE
explicitly mark nullable parameters as nullable

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -148,7 +148,7 @@ class CronExpression
     /**
      * @deprecated since version 3.0.2, use __construct instead.
      */
-    public static function factory(string $expression, FieldFactoryInterface $fieldFactory = null): CronExpression
+    public static function factory(string $expression, ?FieldFactoryInterface $fieldFactory = null): CronExpression
     {
         /** @phpstan-ignore-next-line */
         return new static($expression, $fieldFactory);
@@ -179,7 +179,7 @@ class CronExpression
      * @param null|FieldFactoryInterface $fieldFactory Factory to create cron fields
      * @throws InvalidArgumentException
      */
-    public function __construct(string $expression, FieldFactoryInterface $fieldFactory = null)
+    public function __construct(string $expression, ?FieldFactoryInterface $fieldFactory = null)
     {
         $shortcut = strtolower($expression);
         $expression = self::$registeredAliases[$shortcut] ?? $expression;


### PR DESCRIPTION
not doing this will be deprecated in PHP 8.4 (see e.g. https://github.com/symfony/symfony/actions/runs/8459191951/job/23175036483?pr=54426#step:8:508)