### PR TITLE
chore: upgrade to PHPUnit 11 and 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,4 +74,4 @@ jobs:
         run: composer update --prefer-dist --no-interaction
 
       - name: Analyze & test
-        run: composer test -- -v --coverage-clover=coverage.xml
+        run: composer test --coverage-clover=coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.phar
 composer.lock
 .idea
 .php_cs.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "php": "^8.2|^8.3|^8.4|^8.5"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.12.32|^2.1.31",
-        "phpunit/phpunit": "^8.5.48|^9.0",
+        "phpstan/phpstan": "^2.1.31",
+        "phpunit/phpunit": "^11.5.43 || ^12.4",
         "phpstan/extension-installer": "^1.4.3"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="./vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
 >
 
-    <coverage>
+    <source ignoreSuppressionOfDeprecations="true" restrictNotices="true" restrictWarnings="true">
         <include>
-            <directory suffix=".php">./src/Cron</directory>
+            <directory>./src/Cron</directory>
         </include>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="Cron">

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -8,16 +8,20 @@ use Cron\DayOfWeekField;
 use Cron\HoursField;
 use Cron\MinutesField;
 use Cron\MonthField;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('isRange')]
+#[CoversFunction('isIncrementsOfRanges')]
+#[CoversFunction('isInRange')]
+#[CoversFunction('isInIncrementsOfRanges')]
+#[CoversFunction('isSatisfied')]
 class AbstractFieldTest extends TestCase
 {
-    /**
-     * @covers \Cron\AbstractField::isRange
-     */
+
     public function testTestsIfRange(): void
     {
         $f = new DayOfWeekField();
@@ -25,9 +29,6 @@ class AbstractFieldTest extends TestCase
         $this->assertFalse($f->isRange('2'));
     }
 
-    /**
-     * @covers \Cron\AbstractField::isIncrementsOfRanges
-     */
     public function testTestsIfIncrementsOfRanges(): void
     {
         $f = new DayOfWeekField();
@@ -37,9 +38,6 @@ class AbstractFieldTest extends TestCase
         $this->assertTrue($f->isIncrementsOfRanges('3-12/2'));
     }
 
-    /**
-     * @covers \Cron\AbstractField::isInRange
-     */
     public function testTestsIfInRange(): void
     {
         $f = new DayOfWeekField();
@@ -50,9 +48,6 @@ class AbstractFieldTest extends TestCase
         $this->assertFalse($f->isInRange(13, '4-12'));
     }
 
-    /**
-     * @covers \Cron\AbstractField::isInIncrementsOfRanges
-     */
     public function testTestsIfInIncrementsOfRangesOnZeroStartRange(): void
     {
         $f = new MinutesField();
@@ -74,9 +69,6 @@ class AbstractFieldTest extends TestCase
         $this->assertFalse($f->isInIncrementsOfRanges(34, '4/1'));
     }
 
-    /**
-     * @covers \Cron\AbstractField::isInIncrementsOfRanges
-     */
     public function testTestsIfInIncrementsOfRangesOnOneStartRange(): void
     {
         $f = new MonthField();
@@ -98,9 +90,6 @@ class AbstractFieldTest extends TestCase
         $this->assertFalse($f->isInIncrementsOfRanges(34, '4/1'));
     }
 
-    /**
-     * @covers \Cron\AbstractField::isSatisfied
-     */
     public function testTestsIfSatisfied(): void
     {
         $f = new DayOfWeekField();

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -11,17 +11,35 @@ use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Ticket;
 use PHPUnit\Framework\TestCase;
-use Webmozart\Assert\Assert;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('getNextRunDate')]
+#[CoversClass(\Cron\DayOfMonthField::class)]
+#[CoversClass(\Cron\DayOfWeekField::class)]
+#[CoversClass(\Cron\MinutesField::class)]
+#[CoversClass(\Cron\HoursField::class)]
+#[CoversClass(\Cron\MonthField::class)]
+#[CoversClass(\Cron\CronExpression::class)]
+#[CoversFunction('getRunDate')]
+#[CoversFunction('__construct')]
+#[CoversFunction('getExpression')]
+#[CoversFunction('setExpression')]
+#[CoversFunction('__toString')]
+#[CoversFunction('setPart')]
+#[CoversFunction('isDue')]
+#[CoversFunction('getPreviousRunDate')]
+#[CoversFunction('getMultipleRunDates')]
+#[CoversFunction('setMaxIterationCount')]
+#[CoversFunction('isValidExpression')]
 class CronExpressionTest extends TestCase
 {
-    /**
-     * @covers \Cron\CronExpression::__construct
-     */
     public function testConstructorRecognizesTemplates(): void
     {
         $this->assertSame('0 0 1 1 *', (new CronExpression('@annually'))->getExpression());
@@ -31,11 +49,6 @@ class CronExpressionTest extends TestCase
         $this->assertSame('0 0 * * *', (new CronExpression('@midnight'))->getExpression());
     }
 
-    /**
-     * @covers \Cron\CronExpression::__construct
-     * @covers \Cron\CronExpression::getExpression
-     * @covers \Cron\CronExpression::__toString
-     */
     public function testParsesCronSchedule(): void
     {
         // '2010-09-10 12:00:00'
@@ -50,11 +63,6 @@ class CronExpressionTest extends TestCase
         $this->assertNull($cron->getExpression('foo'));
     }
 
-    /**
-     * @covers \Cron\CronExpression::__construct
-     * @covers \Cron\CronExpression::getExpression
-     * @covers \Cron\CronExpression::__toString
-     */
     public function testParsesCronScheduleThrowsAnException(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -62,14 +70,8 @@ class CronExpressionTest extends TestCase
         new CronExpression('A 1 2 3 4');
     }
 
-    /**
-     * @covers \Cron\CronExpression::__construct
-     * @covers \Cron\CronExpression::getExpression
-     * @dataProvider scheduleWithDifferentSeparatorsProvider
-     *
-     * @param mixed $schedule
-     */
-    public function testParsesCronScheduleWithAnySpaceCharsAsSeparators($schedule, array $expected): void
+    #[DataProvider('scheduleWithDifferentSeparatorsProvider')]
+    public function testParsesCronScheduleWithAnySpaceCharsAsSeparators(mixed $schedule, array $expected): void
     {
         $cron = new CronExpression($schedule);
         $this->assertSame($expected[0], $cron->getExpression(CronExpression::MINUTE));
@@ -94,11 +96,6 @@ class CronExpressionTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Cron\CronExpression::__construct
-     * @covers \Cron\CronExpression::setExpression
-     * @covers \Cron\CronExpression::setPart
-     */
     public function testInvalidCronsWillFail(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -106,9 +103,6 @@ class CronExpressionTest extends TestCase
         $cron = new CronExpression('* * * 1');
     }
 
-    /**
-     * @covers \Cron\CronExpression::setPart
-     */
     public function testInvalidPartsWillFail(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -122,7 +116,7 @@ class CronExpressionTest extends TestCase
      *
      * @return array
      */
-    public function scheduleProvider(): array
+    public static function scheduleProvider(): array
     {
         return [
             ['*/2 */2 * * *', '2015-08-10 21:47:27', '2015-08-10 22:00:00', false],
@@ -209,21 +203,12 @@ class CronExpressionTest extends TestCase
     }
 
     /**
-     * @covers \Cron\CronExpression::isDue
-     * @covers \Cron\CronExpression::getNextRunDate
-     * @covers \Cron\DayOfMonthField
-     * @covers \Cron\DayOfWeekField
-     * @covers \Cron\MinutesField
-     * @covers \Cron\HoursField
-     * @covers \Cron\MonthField
-     * @covers \Cron\CronExpression::getRunDate
-     * @dataProvider scheduleProvider
-     *
      * @param mixed $schedule
      * @param mixed $relativeTime
      * @param mixed $nextRun
      * @param mixed $isDue
      */
+    #[DataProvider('scheduleProvider')]
     public function testDeterminesIfCronIsDue($schedule, $relativeTime, $nextRun, $isDue): void
     {
         // Test next run date
@@ -247,9 +232,6 @@ class CronExpressionTest extends TestCase
         $this->assertEquals($nextRunDate, $next);
     }
 
-    /**
-     * @covers \Cron\CronExpression::isDue
-     */
     public function testIsDueHandlesDifferentDates(): void
     {
         $cron = new CronExpression('* * * * *');
@@ -260,9 +242,6 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($cron->isDue(new DateTimeImmutable('now')));
     }
 
-    /**
-     * @covers \Cron\CronExpression::isDue
-     */
     public function testIsDueHandlesDifferentDefaultTimezones(): void
     {
         $originalTimezone = date_default_timezone_get();
@@ -287,9 +266,6 @@ class CronExpressionTest extends TestCase
         date_default_timezone_set($originalTimezone);
     }
 
-    /**
-     * @covers \Cron\CronExpression::isDue
-     */
     public function testIsDueHandlesDifferentSuppliedTimezones(): void
     {
         $cron = new CronExpression('0 15 * * 3'); //Wednesday at 15:00
@@ -308,9 +284,6 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($cron->isDue(new DateTime($date, new DateTimeZone('Asia/Tokyo')), 'Asia/Tokyo'));
     }
 
-    /**
-     * @covers \Cron\CronExpression::isDue
-     */
     public function testIsDueHandlesDifferentTimezonesAsArgument(): void
     {
         $cron = new CronExpression('0 15 * * 3'); //Wednesday at 15:00
@@ -329,9 +302,6 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($cron->isDue(new DateTime($date, $tokyo), 'Asia/Tokyo'));
     }
 
-    /**
-     * @covers \Cron\CronExpression::isDue
-     */
     public function testRecognisesTimezonesAsPartOfDateTime(): void
     {
         $cron = new CronExpression('0 7 * * *');
@@ -368,9 +338,6 @@ class CronExpressionTest extends TestCase
         $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getPreviousRunDate
-     */
     public function testCanGetPreviousRunDates(): void
     {
         $cron = new CronExpression('* * * * *');
@@ -389,9 +356,6 @@ class CronExpressionTest extends TestCase
         $this->assertEquals($next, $cron->getPreviousRunDate($two));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getMultipleRunDates
-     */
     public function testProvidesMultipleRunDates(): void
     {
         $cron = new CronExpression('*/2 * * * *');
@@ -403,10 +367,6 @@ class CronExpressionTest extends TestCase
         ], $cron->getMultipleRunDates(4, '2008-11-09 00:00:00', false, true));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getMultipleRunDates
-     * @covers \Cron\CronExpression::setMaxIterationCount
-     */
     public function testProvidesMultipleRunDatesForTheFarFuture(): void
     {
         // Fails with the default 1000 iteration limit
@@ -425,9 +385,6 @@ class CronExpressionTest extends TestCase
         ], $cron->getMultipleRunDates(9, '2015-04-28 00:00:00', false, true));
     }
 
-    /**
-     * @covers \Cron\CronExpression
-     */
     public function testCanIterateOverNextRuns(): void
     {
         $cron = new CronExpression('@weekly');
@@ -445,9 +402,6 @@ class CronExpressionTest extends TestCase
         $this->assertEquals($nextRun, new DateTime('2008-11-30 00:00:00'));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getRunDate
-     */
     public function testGetRunDateHandlesDifferentDates(): void
     {
         $cron = new CronExpression('@weekly');
@@ -463,7 +417,6 @@ class CronExpressionTest extends TestCase
      *
      * Previously the earliest of dates was always returned, which was incorrect for previous run date.
      *
-     * @covers \Cron\CronExpression::getRunDate
      */
     public function testGetRunDateHandlesSimultaneousDayOfMonthAndDayOfWeek(): void
     {
@@ -473,9 +426,6 @@ class CronExpressionTest extends TestCase
         $this->assertEquals(new DateTime("2021-07-14 00:00:00"), $cron->getPreviousRunDate($date));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getRunDate
-     */
     public function testSkipsCurrentDateByDefault(): void
     {
         $cron = new CronExpression('* * * * *');
@@ -485,10 +435,7 @@ class CronExpressionTest extends TestCase
         $this->assertSame($current->format('Y-m-d H:i:00'), $nextPrev->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getRunDate
-     * @ticket 7
-     */
+    #[Ticket("7")]
     public function testStripsForSeconds(): void
     {
         $cron = new CronExpression('* * * * *');
@@ -496,9 +443,6 @@ class CronExpressionTest extends TestCase
         $this->assertSame('2011-09-27 10:11:00', $cron->getNextRunDate($current)->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getRunDate
-     */
     public function testFixesPhpBugInDateIntervalMonth(): void
     {
         $cron = new CronExpression('0 0 27 JAN *');
@@ -535,9 +479,6 @@ class CronExpressionTest extends TestCase
         $this->assertFalse($e->isDue(new DateTime('2014-04-27 00:00:00')));
     }
 
-    /**
-     * @covers \Cron\CronExpression::getRunDate
-     */
     public function testKeepOriginalTime(): void
     {
         $now = new \DateTime();
@@ -547,12 +488,6 @@ class CronExpressionTest extends TestCase
         $this->assertSame($strNow, $now->format(DateTime::ISO8601));
     }
 
-    /**
-     * @covers \Cron\CronExpression::__construct
-     * @covers \Cron\CronExpression::isValidExpression
-     * @covers \Cron\CronExpression::setExpression
-     * @covers \Cron\CronExpression::setPart
-     */
     public function testValidationWorks(): void
     {
         // Invalid. Only four values

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -7,16 +7,17 @@ namespace Cron\Tests;
 use Cron\DayOfMonthField;
 use DateTime;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('increment')]
+#[CoversFunction('validate')]
+#[CoversFunction('isSatisfiedBy')]
 class DayOfMonthFieldTest extends TestCase
 {
-    /**
-     * @covers \Cron\DayOfMonthField::validate
-     */
     public function testValidatesField(): void
     {
         $f = new DayOfMonthField();
@@ -30,9 +31,6 @@ class DayOfMonthFieldTest extends TestCase
         $this->assertFalse($f->validate('1.'));
     }
 
-    /**
-     * @covers \Cron\DayOfMonthField::isSatisfiedBy
-     */
     public function testChecksIfSatisfied(): void
     {
         $f = new DayOfMonthField();
@@ -40,9 +38,6 @@ class DayOfMonthFieldTest extends TestCase
         $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
-    /**
-     * @covers \Cron\DayOfMonthField::increment
-     */
     public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
@@ -55,9 +50,6 @@ class DayOfMonthFieldTest extends TestCase
         $this->assertSame('2011-03-14 23:59:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\DayOfMonthField::increment
-     */
     public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
@@ -78,9 +70,6 @@ class DayOfMonthFieldTest extends TestCase
         $this->assertFalse($f->validate('0'));
     }
 
-    /**
-     * @covers \Cron\MinutesField::increment
-     */
     public function testIncrementAcrossDstChangeBerlin(): void
     {
         $tz = new \DateTimeZone("Europe/Berlin");
@@ -95,9 +84,6 @@ class DayOfMonthFieldTest extends TestCase
         $this->assertSame("2021-03-27 23:59:00", $d->format("Y-m-d H:i:s"));
     }
 
-    /**
-     * @covers \Cron\MinutesField::increment
-     */
     public function testIncrementAcrossDstChangeLondon(): void
     {
         $tz = new \DateTimeZone("Europe/London");

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -8,16 +8,17 @@ use Cron\DayOfWeekField;
 use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('validate')]
+#[CoversFunction('isSatisfiedBy')]
+#[CoversFunction('increment')]
 class DayOfWeekFieldTest extends TestCase
 {
-    /**
-     * @covers \Cron\DayOfWeekField::validate
-     */
     public function testValidatesField(): void
     {
         $f = new DayOfWeekField();
@@ -31,9 +32,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertFalse($f->validate('1.'));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     */
     public function testChecksIfSatisfied(): void
     {
         $f = new DayOfWeekField();
@@ -41,9 +39,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::increment
-     */
     public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
@@ -56,9 +51,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertSame('2011-03-14 23:59:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::increment
-     */
     public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
@@ -67,9 +59,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertSame('2011-03-16 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     */
     public function testValidatesHashValueWeekday(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -78,9 +67,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '12#1', false));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     */
     public function testValidatesHashValueNth(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -89,9 +75,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '3#6', false));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::validate
-     */
     public function testValidateWeekendHash(): void
     {
         $f = new DayOfWeekField();
@@ -105,9 +88,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->validate('MON#1,MON#3'));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     */
     public function testHandlesZeroAndSevenDayOfTheWeekValues(): void
     {
         $f = new DayOfWeekField();
@@ -120,9 +100,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), '7#3', false));
     }
 
-    /**
-     * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     */
     public function testHandlesLastWeekdayOfTheMonth(): void
     {
         $f = new DayOfWeekField();

--- a/tests/Cron/DaylightSavingsTest.php
+++ b/tests/Cron/DaylightSavingsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Cron\Tests;
 
 use Cron\CronExpression;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 
 class DaylightSavingsTest extends TestCase
@@ -114,8 +116,8 @@ class DaylightSavingsTest extends TestCase
     /**
      * Skip due to PHP 8.1 date instabilities.
      * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
-     * @requires PHP <= 8.0.22
      */
+    #[RequiresPhp('<=8.0.22')]
     public function testOffsetDecrementsNextRunDateAllowCurrent(): void
     {
         $tz = new \DateTimeZone("Europe/London");
@@ -151,8 +153,8 @@ class DaylightSavingsTest extends TestCase
      * This can be avoided by using disallowing the current date or with additional checks outside this library
      * Skip due to PHP 8.1 date instabilities.
      * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
-     * @requires PHP <= 8.0.22
      */
+    #[RequiresPhp('<=8.0.22')]
     public function testOffsetDecrementsNextRunDateDisallowCurrent(): void
     {
         $tz = new \DateTimeZone("Europe/London");
@@ -303,8 +305,8 @@ class DaylightSavingsTest extends TestCase
     /**
      * @param string[] $expected
      *
-     * @dataProvider dayLightSavingExamples
      */
+    #[DataProvider('dayLightSavingExamples')]
     public function testOffsetIncrementsMultipleRunDates(
         string $expression,
         array $expected,
@@ -338,8 +340,8 @@ class DaylightSavingsTest extends TestCase
     /**
      * Skip due to PHP 8.1 date instabilities.
      * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
-     * @requires PHP <= 8.0.22
      */
+    #[RequiresPhp('<=8.0.22')]
     public function testOffsetDecrementsMultipleRunDates(): void
     {
         $expression = "0 1 * * 0";
@@ -430,8 +432,8 @@ class DaylightSavingsTest extends TestCase
     /**
      * Skip due to PHP 8.1 date instabilities.
      * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
-     * @requires PHP <= 8.0.22
      */
+    #[RequiresPhp('<=8.0.22')]
     public function testOffsetDecrementsEveryOtherHour(): void
     {
         $expression = "0 */2 * * *";

--- a/tests/Cron/FieldFactoryTest.php
+++ b/tests/Cron/FieldFactoryTest.php
@@ -6,16 +6,15 @@ namespace Cron\Tests;
 
 use Cron\FieldFactory;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('getField')]
 class FieldFactoryTest extends TestCase
 {
-    /**
-     * @covers \Cron\FieldFactory::getField
-     */
     public function testRetrievesFieldInstances(): void
     {
         $mappings = [
@@ -33,9 +32,6 @@ class FieldFactoryTest extends TestCase
         }
     }
 
-    /**
-     * @covers \Cron\FieldFactory::getField
-     */
     public function testValidatesFieldPosition(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -7,16 +7,17 @@ namespace Cron\Tests;
 use Cron\HoursField;
 use DateTime;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('validate')]
+#[CoversFunction('increment')]
 class HoursFieldTest extends TestCase
 {
-    /**
-     * @covers \Cron\HoursField::validate
-     */
+
     public function testValidatesField(): void
     {
         $f = new HoursField();
@@ -28,9 +29,6 @@ class HoursFieldTest extends TestCase
         $this->assertFalse($f->validate('1/10'));
     }
 
-    /**
-     * @covers \Cron\HoursField::increment
-     */
     public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
@@ -43,9 +41,6 @@ class HoursFieldTest extends TestCase
         $this->assertSame('2011-03-15 10:59:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\HoursField::increment
-     */
     public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
@@ -54,9 +49,6 @@ class HoursFieldTest extends TestCase
         $this->assertSame('2011-03-15 12:00:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\HoursField::increment
-     */
     public function testIncrementsDateWithThirtyMinuteOffsetTimezone(): void
     {
         $tz = date_default_timezone_get();
@@ -72,9 +64,6 @@ class HoursFieldTest extends TestCase
         date_default_timezone_set($tz);
     }
 
-    /**
-     * @covers \Cron\HoursField::increment
-     */
     public function testIncrementDateWithFifteenMinuteOffsetTimezone(): void
     {
         $tz = date_default_timezone_get();
@@ -90,9 +79,6 @@ class HoursFieldTest extends TestCase
         date_default_timezone_set($tz);
     }
 
-    /**
-     * @covers \Cron\HoursField::increment
-     */
     public function testIncrementAcrossDstChangeBerlin(): void
     {
         $tz = new \DateTimeZone("Europe/Berlin");
@@ -113,9 +99,6 @@ class HoursFieldTest extends TestCase
         $this->assertSame("2021-03-27 23:59:00", $d->format("Y-m-d H:i:s"));
     }
 
-    /**
-     * @covers \Cron\HoursField::increment
-     */
     public function testIncrementAcrossDstChangeLondon(): void
     {
         $tz = new \DateTimeZone("Europe/London");

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -7,16 +7,18 @@ namespace Cron\Tests;
 use Cron\MinutesField;
 use DateTime;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('validate')]
+#[CoversFunction('isSatisfiedBy')]
+#[CoversFunction('increment')]
 class MinutesFieldTest extends TestCase
 {
-    /**
-     * @covers \Cron\MinutesField::validate
-     */
+
     public function testValidatesField(): void
     {
         $f = new MinutesField();
@@ -26,9 +28,7 @@ class MinutesFieldTest extends TestCase
         $this->assertFalse($f->validate('1/10'));
     }
 
-    /**
-     * @covers \Cron\MinutesField::isSatisfiedBy
-     */
+
     public function testChecksIfSatisfied(): void
     {
         $f = new MinutesField();
@@ -36,9 +36,6 @@ class MinutesFieldTest extends TestCase
         $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
-    /**
-     * @covers \Cron\MinutesField::increment
-     */
     public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
@@ -50,9 +47,6 @@ class MinutesFieldTest extends TestCase
         $this->assertSame('2011-03-15 11:15:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\MinutesField::increment
-     */
     public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
@@ -90,9 +84,6 @@ class MinutesFieldTest extends TestCase
         $this->assertFalse($f->validate('0/5'));
     }
 
-    /**
-     * @covers \Cron\MinutesField::increment
-     */
     public function testIncrementAcrossDstChangeBerlin(): void
     {
         $tz = new \DateTimeZone("Europe/Berlin");
@@ -107,9 +98,6 @@ class MinutesFieldTest extends TestCase
         $this->assertSame("2021-03-28 01:58:00", $d->format("Y-m-d H:i:s"));
     }
 
-    /**
-     * @covers \Cron\MinutesField::increment
-     */
     public function testIncrementAcrossDstChangeLondon(): void
     {
         $tz = new \DateTimeZone("Europe/London");

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -7,16 +7,17 @@ namespace Cron\Tests;
 use Cron\MonthField;
 use DateTime;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
  */
+#[CoversFunction('isSatisfiedBy')]
+#[CoversFunction('validate')]
+#[CoversFunction('increment')]
 class MonthFieldTest extends TestCase
 {
-    /**
-     * @covers \Cron\MonthField::validate
-     */
     public function testValidatesField(): void
     {
         $f = new MonthField();
@@ -27,9 +28,6 @@ class MonthFieldTest extends TestCase
         $this->assertFalse($f->validate('1/10'));
     }
 
-    /**
-     * @covers \Cron\MonthField::isSatisfiedBy
-     */
     public function testChecksIfSatisfied(): void
     {
         $f = new MonthField();
@@ -37,9 +35,6 @@ class MonthFieldTest extends TestCase
         $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
-    /**
-     * @covers \Cron\MonthField::increment
-     */
     public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
@@ -52,9 +47,6 @@ class MonthFieldTest extends TestCase
         $this->assertSame('2011-02-28 23:59:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\MonthField::increment
-     */
     public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
@@ -63,9 +55,6 @@ class MonthFieldTest extends TestCase
         $this->assertSame('2011-04-01 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\MonthField::increment
-     */
     public function testIncrementsDateWithThirtyMinuteTimezone(): void
     {
         $tz = date_default_timezone_get();
@@ -81,9 +70,6 @@ class MonthFieldTest extends TestCase
         date_default_timezone_set($tz);
     }
 
-    /**
-     * @covers \Cron\MonthField::increment
-     */
     public function testIncrementsYearAsNeeded(): void
     {
         $f = new MonthField();
@@ -92,9 +78,6 @@ class MonthFieldTest extends TestCase
         $this->assertSame('2012-01-01 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @covers \Cron\MonthField::increment
-     */
     public function testDecrementsYearAsNeeded(): void
     {
         $f = new MonthField();


### PR DESCRIPTION
remove phpstan/phpstan 1 (not longer needed with PHP bump)
the `-v` option does not longer exists in the phpunit cli

i did not remove the tests for < PHP 8.1
Maybe someone wants to rewrite the tests in the future