### PR TITLE
Fixed handling of LW as the day of month.

### DIFF
--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -96,7 +96,8 @@ class DayOfMonthField extends AbstractField
         // Check to see if this is the nearest weekday to a particular value
         if ($wPosition = strpos($value, 'W')) {
             // Parse the target day
-            $targetDay = (int) substr($value, 0, $wPosition);
+            $targetDay = substr($value, 0, $wPosition);
+            $targetDay = ($targetDay == 'L') ? (int) $date->format('t') : (int) substr($value, 0, $wPosition);
             // Find out if the current day is the nearest day of the week
             $nearest = self::getNearestWeekday(
                 (int) $date->format('Y'),


### PR DESCRIPTION
This change allows for the use of LW as the day of month.  

For example, in July 2026 LW in the day of month would result in 7-30-26 rather than 7-31-26.  This change fixes that.