### PR TITLE
fix: do not skip midnight after daylight saving starts

### DIFF
--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -184,7 +184,7 @@ class HoursField extends AbstractField
             }
 
             $distance = $target - $originalHour;
-            $date = $this->timezoneSafeModify($date, "+{$distance} hours");
+            $date = $this->timezoneSafeModify($date, "{$distance} hours");
         } else {
             if ($originalHour <= $target) {
                 $distance = ($originalHour + 1);

--- a/tests/Cron/DaylightSavingsTest.php
+++ b/tests/Cron/DaylightSavingsTest.php
@@ -83,6 +83,17 @@ class DaylightSavingsTest extends TestCase
         $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
     }
 
+    public function testNextMidnightIsNotSkippedAcrossSpringDstTransition(): void
+    {
+        $tz = new \DateTimeZone("Europe/Prague");
+        $cron = new CronExpression("0 0 * * *");
+
+        $dtCurrent = $this->createDateTimeExactly("2026-03-29 00:30+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2026-03-30 00:00+02:00", $tz);
+
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+    }
+
     public function testOffsetIncrementsPreviousRunDate(): void
     {
         $tz = new \DateTimeZone("Europe/London");


### PR DESCRIPTION
## Summary

- preserve the sign of the target-hour distance during forward calculations
- add a regression test for a daily midnight schedule across the spring DST transition

## Problem

When a spring DST offset change makes the calculated target-hour distance negative, the forward path prefixes it with another plus sign. A distance of `-1` therefore becomes the modifier `"+-1 hours"`, which PHP interprets as a positive one-hour interval.

For `0 0 * * *` in `Europe/Prague`, starting at `2026-03-29 00:30:00 +01:00`, this leaves the candidate at 01:00 instead of midnight. The next iteration then advances to March 31 and skips the valid March 30 midnight occurrence.

Passing the already signed distance unchanged produces `"-1 hours"` and keeps positive distances valid as well.

This is a remaining edge case related to #154, #202, and #203.

## Tests

- `composer test` - 176 tests, 803 assertions, 4 skipped
- `composer phpstan` - no errors


Fixes #220
